### PR TITLE
Troubleshooting Capstone

### DIFF
--- a/modules/lms/files/troubleshooting/scripts/capstone.sh
+++ b/modules/lms/files/troubleshooting/scripts/capstone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Set up a wonky site.pp
+cat > /etc/puppetlabs/puppet/environments/production/manifests/site.pp << EOM
+filebucket { 'main':
+  server => 'learning.puppetlabs.vm',
+  path   => false,
+}
+
+File { backup => 'main' }
+
+node default {
+  file_line { 'updates':
+      path  => '/etc/puppetlabs/puppet/puppet.conf',
+      line  => 'server = training.puppetlabs.vm',
+      match => '^\s*server.*',
+  }
+}
+EOM
+
+# Hide all output from the puppet run
+puppet agent -t >/dev/null 2>/dev/null

--- a/modules/lms/files/troubleshooting/scripts/restore.sh
+++ b/modules/lms/files/troubleshooting/scripts/restore.sh
@@ -15,4 +15,4 @@ File { backup => 'main' }
 node default {
 }
 EOM
-
+sed -i 's/training.puppetlabs.vm/learning.puppetlabs.vm/' /etc/puppetlabs/puppet/puppet.conf

--- a/modules/lms/files/troubleshooting/scripts/restore.sh
+++ b/modules/lms/files/troubleshooting/scripts/restore.sh
@@ -3,3 +3,16 @@
 rm -f /EMPTY
 sed -i 's/:wq//' /etc/puppetlabs/puppet/puppet.conf
 rm -rf /labs
+
+cat > /etc/puppetlabs/puppet/environments/production/manifests/site.pp << EOM
+filebucket { 'main':
+  server => 'learning.puppetlabs.vm',
+  path   => false,
+}
+
+File { backup => 'main' }
+
+node default {
+}
+EOM
+


### PR DESCRIPTION
These are the scripts students will run for the capstone.
capstone.sh sets up a site.pp which will break puppet.conf by setting the wrong server name.  It also runs puppet once while suppressing the output to simulate a change being made by someone else.

The additions to restore.sh will undo those changes. (although that isn't strictly necessary because this is the capstone).