### PR TITLE
Double menu size for LMS vm

### DIFF
--- a/scripts/course_menu.rb.erb
+++ b/scripts/course_menu.rb.erb
@@ -53,7 +53,7 @@ begin
   nonl
   cbreak
 
-  menu = Window.new(24,76,0,2)
+  menu = Window.new(48,152,0,2)
   menu.box('|','-')
   menu.keypad = true
 


### PR DESCRIPTION
The Centos7 VMs have a much larger default console.  This makes use of the whole screen instead of a corner