### PR TITLE
Add Noop Production validation

### DIFF
--- a/_lmscontent/Gemfile
+++ b/_lmscontent/Gemfile
@@ -5,4 +5,7 @@ source 'https://rubygems.org' do
   gem 'upmark'
   gem 'reverse_markdown'
   gem 'rake'
+  gem 'diffy'
+  gem 'html_validation'
+  gem 'paint'
 end


### PR DESCRIPTION
Prior to this commit, we did not know what the changes in production would look
like. This is due to the round trip the markdown has taken from HTML to MD back
to HTML again. This new `rake` task adds essentially a noop mode that will
detect the changes between tags and display them on the command line for all
fields that have html that differs between whats in production and whats
currently being rendered from the markdown. It should be run ahead of the first
production push.