### PR TITLE
Fix download:repos rake task for laptop users

### DIFF
--- a/_lmscontent/_tasks/download.rake
+++ b/_lmscontent/_tasks/download.rake
@@ -27,7 +27,7 @@ namespace :download do
     @config['repos'].each do |key,hash|
       puts "Updating repo #{key} #{hash['url']}"
 
-      sha = File.read('../.git/refs/heads/master')
+      sha = File.read('../.git/refs/heads/master').chomp
       if Dir.exist?("repos/#{key}")
         # If repo already exists fetch and reset (pull)
         repo = Rugged::Repository.discover("repos/#{key}")


### PR DESCRIPTION
Prior to this commit laptop users of the rake task to download the repos
would receive an error because the string used to hard reset the repo had
a newline. This meant the only way to run the task was to delete the repos
directory.