### PR TITLE
(TRAINTECH-1721) Automatically convert non-ascii chars

### DIFF
--- a/_lmscontent/_tasks/upload.rake
+++ b/_lmscontent/_tasks/upload.rake
@@ -4,6 +4,7 @@ require 'learndot/learning_components'
 require 'yaml'
 require 'json'
 require 'kramdown'
+require 'stringex'
 
 # This set of tasks are the primary code for uploading content to learndot.
 
@@ -52,6 +53,16 @@ namespace :upload do
     @lms.create_component(conditions)
   end
 
+  def convert_to_ascii(string)
+    string.gsub(/[”“‘’]/,
+      '”' => '"',
+      '“' => '"',
+      '‘' => '\'',
+      '’' => '\''
+    )
+    string.to_ascii
+  end
+
   # Rake Tasks
   task :component,[:component_directory,:target] do  |_t, args|
 
@@ -78,7 +89,15 @@ namespace :upload do
       if File.exist?("#{component_directory}/#{field}.md")
         puts "Converting #{field}.md to html"
         doc = Kramdown::Document.new(File.read("#{component_directory}/#{field}.md"))
-        metadata[field] = doc.to_html
+
+        # Kramdown can't handle non-ascii characters so we check and "fix" if
+        # we can. to_ascii comes from the stringex gem above
+        if doc.force_encoding('UTF-8').ascii_only?
+          metadata[field] = doc.force_encoding('UTF-8').to_html
+        else
+          puts "WARNING: Non ascii characters detected attempting to replace them"
+          metadata[field] = doc.convert_to_ascii.force_encoding('UTF-8').to_html
+        end
       end
     end
 


### PR DESCRIPTION
Prior to this commit users had to manually run the rake task to
convert non-ascii chars. This commit attempts to fix this by forcing UTF-8
and attempting to detect non-ascii chars and then find and replace them.