### PR TITLE
(TRAINTECH-1714 ) Check if file is empty in addition to non-existant

### DIFF
--- a/_lmscontent/_tasks/upload.rake
+++ b/_lmscontent/_tasks/upload.rake
@@ -86,7 +86,12 @@ namespace :upload do
       'description',
       'summary',
     ].each do |field|
-      if File.exist?("#{component_directory}/#{field}.md")
+      # We check if the file exists and do not edit the field if it doesn't
+      next unless File.exist?("#{component_directory}/#{field}.md")
+      markdown = File.read("#{component_directory}/#{field}.md")
+
+      # Check if the file is simply a place holder and just whitespace (blank)
+      if /\A[[:space:]]*\z/.match(markdown).nil?
         puts "Converting #{field}.md to html"
         markdown = File.read("#{component_directory}/#{field}.md")
 
@@ -98,6 +103,8 @@ namespace :upload do
         end
         doc = Kramdown::Document.new(markdown)
         metadata[field] = doc.to_html
+      else
+        puts "NOTICE: #{component_directory}/#{field}.md is blank, skipping"
       end
     end
 


### PR DESCRIPTION
Prior to this commit we only checked if the file existed. This commit
checks if the file is "blank" and simply a place holder. This should prevent
empty lines being uploaded to learndot and the formatting to be weird. These
fields are not required in the interface and thus shouldn't be required here
when place holders are present.